### PR TITLE
remove the code for calling delaysearch.R from gitHub because it is unce...

### DIFF
--- a/readPolariS.R
+++ b/readPolariS.R
@@ -1,5 +1,3 @@
-library(RCurl)
-eval(parse(text = getURL("https://raw.githubusercontent.com/kamenoseiji/PolaR/master/delaysearch.R", ssl.verifypeer = FALSE)))
 readPolariS <- function(fname, chnum=131072){
 	head_size <- 128						# 128-byte Header
 	file_size <- file.info(fname)$size		# File size [byte]


### PR DESCRIPTION
...rtai

I call delayserch.R before calling readPolariS.R with source("delayserch
Removed code:
  library(RCurl)
  eval(parse(text = getURL("https://raw.githubusercontent.com/kamenoseiji/
